### PR TITLE
chore: update deploy scripts

### DIFF
--- a/contracts/deployment-config/KeystoreValidator.json
+++ b/contracts/deployment-config/KeystoreValidator.json
@@ -1,0 +1,3 @@
+{
+    "bridge": "0x9142BfBbA6eA6471C9eb9C39b3492F48B9a51EbF"
+}

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -7,7 +7,7 @@ solc = "0.8.26"
 optimizer = true
 optimizer_runs = 100000
 evm_version = "cancun"
-fs_permissions = [{ access = "read", path = "proofs"}]
+fs_permissions = [{ access = "read", path = "proofs"}, { access = "read", path = "./deployment-config"}]
 
 [fmt]
   bracket_spacing = true


### PR DESCRIPTION
This PR removes the ECDSA consumer deployment from the deploy script. This will be done from the `auth-ecdsa` repo. Inputs are also read from JSON now.