### PR TITLE
refactor: abstract chain specific elements out of state oracle

### DIFF
--- a/contracts/script/KeystoreValidator.s.sol
+++ b/contracts/script/KeystoreValidator.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.26;
 
 import { StorageProofVerifier } from "../src/StorageProofVerifier.sol";
-import { KeystoreStateOracle } from "../src/KeystoreStateOracle.sol";
+import { OPStackStateOracle } from "../src/state/OPStackStateOracle.sol";
 import { KeystoreValidator } from "../src/KeystoreValidator.sol";
 import { ECDSAConsumer } from "../test/example/ECDSAConsumer.sol";
 
@@ -38,13 +38,13 @@ contract KeystoreValidatorScript is Script {
         }
     }
 
-    function run() external broadcast returns (StorageProofVerifier, KeystoreStateOracle, KeystoreValidator) {
+    function run() external broadcast returns (StorageProofVerifier, OPStackStateOracle, KeystoreValidator) {
         string memory config = vm.readFile(configPath);
         address bridge = vm.parseJsonAddress(config, ".bridge");
 
         StorageProofVerifier storageProofVerifier = new StorageProofVerifier();
 
-        KeystoreStateOracle stateOracle = new KeystoreStateOracle({
+        OPStackStateOracle stateOracle = new OPStackStateOracle({
             _storageProofVerifier: storageProofVerifier,
             keystoreBridgeAddress: bridge,
             keystoreStateRootStorageSlot: 0xc94330da5d5688c06df0ade6bfd773c87249c0b9f38b25021e2c16ab9672d000

--- a/contracts/src/state/KeystoreStateOracle.sol
+++ b/contracts/src/state/KeystoreStateOracle.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IKeystoreStateOracle } from "../interfaces/IKeystoreStateOracle.sol";
+
+abstract contract KeystoreStateOracle is IKeystoreStateOracle {
+    error InvalidOutputRoot(bytes32 derivedOutputRoot, bytes32 keystoreOutputRoot);
+
+    bytes32 public latestStateRoot;
+    mapping(bytes32 keystoreStateRoot => uint48 l1BlockTimestamp) public keystoreStateRoots;
+
+    address public immutable KEYSTORE_BRIDGE_ADDRESS;
+    bytes32 public immutable KEYSTORE_STATE_ROOT_STORAGE_SLOT;
+
+    // We probably won't want to use `msg.sender` if using a factory for deployment
+    constructor(address keystoreBridgeAddress, bytes32 keystoreStateRootStorageSlot) {
+        KEYSTORE_BRIDGE_ADDRESS = keystoreBridgeAddress;
+        KEYSTORE_STATE_ROOT_STORAGE_SLOT = keystoreStateRootStorageSlot;
+    }
+
+    // TODO: Add this back in with check on msg.sender == canonicalBridge and l1Sender == broadcaster
+    // function cacheKeystoreStateRootNative(
+    //     bytes32 keystoreOutputRoot,
+    //     uint48 l1BlockTimestamp,
+    //     OutputRootPreimage calldata outputRootPreimage
+    // ) external {
+    // }
+}

--- a/contracts/src/state/KeystoreStateOracle.sol
+++ b/contracts/src/state/KeystoreStateOracle.sol
@@ -12,7 +12,6 @@ abstract contract KeystoreStateOracle is IKeystoreStateOracle {
     address public immutable KEYSTORE_BRIDGE_ADDRESS;
     bytes32 public immutable KEYSTORE_STATE_ROOT_STORAGE_SLOT;
 
-    // We probably won't want to use `msg.sender` if using a factory for deployment
     constructor(address keystoreBridgeAddress, bytes32 keystoreStateRootStorageSlot) {
         KEYSTORE_BRIDGE_ADDRESS = keystoreBridgeAddress;
         KEYSTORE_STATE_ROOT_STORAGE_SLOT = keystoreStateRootStorageSlot;

--- a/contracts/test/KeystoreValidator.t.sol
+++ b/contracts/test/KeystoreValidator.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { KeystoreStateOracle } from "../src/KeystoreStateOracle.sol";
+import { OPStackStateOracle } from "../src/state/OPStackStateOracle.sol";
 import { KeystoreValidator } from "../src/KeystoreValidator.sol";
 import { KeystoreIMT } from "../src/libraries/KeystoreIMT.sol";
 import { ECDSAConsumer } from "./example/ECDSAConsumer.sol";
@@ -23,7 +23,7 @@ contract KeystoreValidatorTest is RhinestoneModuleKit, Test {
     using ModuleKitHelpers for AccountInstance;
 
     AccountInstance internal instance;
-    KeystoreStateOracle internal stateOracle;
+    OPStackStateOracle internal stateOracle;
     KeystoreValidator internal validator;
     ECDSAConsumer internal consumer;
 
@@ -41,7 +41,7 @@ contract KeystoreValidatorTest is RhinestoneModuleKit, Test {
         init();
 
         newStorageProofVerifier = (new StorageProofVerifier());
-        stateOracle = new KeystoreStateOracle(
+        stateOracle = new OPStackStateOracle(
             newStorageProofVerifier,
             0xC6011d6b4b11948D733198277B3729d195c99f9D,
             0xc94330da5d5688c06df0ade6bfd773c87249c0b9f38b25021e2c16ab9672d000
@@ -76,7 +76,7 @@ contract KeystoreValidatorTest is RhinestoneModuleKit, Test {
             storageProof: storageProof
         });
 
-        stateOracle.cacheKeystoreStateRoot(
+        stateOracle.cacheKeystoreStateRootWithProof(
             _storageProof,
             IKeystoreStateOracle.OutputRootPreimage({
                 stateRoot: bytes32(0x3c88834ecd749dae9348033b2a889acad890fa045f84061d2347dba67facda8c),


### PR DESCRIPTION
In preparation of allowing bridging of state roots, this PR abstracts away OPStack-specific parts from the core state oracle. Most notably, storage proof logic is separated.