### PR TITLE
feat: add support for bridging state roots across an arbitrum bridge

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -9,6 +9,11 @@ optimizer_runs = 100000
 evm_version = "cancun"
 fs_permissions = [{ access = "read", path = "proofs"}, { access = "read", path = "./deployment-config"}]
 
+[rpc_endpoints]
+sepolia = "${RPC_URL_11155111}"
+base_sepolia = "${RPC_URL_84532}"
+arbitrum_sepolia = "${RPC_URL_421614}"
+
 [fmt]
   bracket_spacing = true
   int_types = "long"

--- a/contracts/script/ArbitrumStateOracle.s.sol
+++ b/contracts/script/ArbitrumStateOracle.s.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { ArbitrumStateOracle } from "../src/state/ArbitrumStateOracle.sol";
+import { ArbitrumBroadcaster } from "../src/broadcast/ArbitrumBroadcaster.sol";
+import { IAxiomKeystoreRollup } from "../src/interfaces/IAxiomKeystoreRollup.sol";
+
+import { ICreateX } from "./ICreateX.sol";
+
+import { Script, safeconsole as console, console2 } from "forge-std/Script.sol";
+
+contract MockBridge is IAxiomKeystoreRollup {
+    bytes32 public latestOutputRoot = keccak256(
+        abi.encodePacked(
+            bytes32(0x870887a884726c27d70b6242ca8978e047d697e0240a021c66201243aa57ac8b),
+            bytes32(0x870887a884726c27d70b6242ca8978e047d697e0240a021c66201243aa57ac8b),
+            bytes32(0x870887a884726c27d70b6242ca8978e047d697e0240a021c66201243aa57ac8b)
+        )
+    );
+}
+
+contract ArbitrumStateOracleScript is Script {
+    /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.
+    string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
+
+    address internal broadcaster;
+
+    string internal mnemonic;
+
+    string configPath = "./deployment-config/KeystoreValidator.json";
+
+    modifier broadcast() {
+        vm.startBroadcast(broadcaster);
+        _;
+        vm.stopBroadcast();
+    }
+
+    constructor() {
+        address from = vm.envOr({ name: "ETH_FROM", defaultValue: address(0) });
+        if (from != address(0)) {
+            broadcaster = from;
+        } else {
+            mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
+            (broadcaster,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
+        }
+    }
+
+    function run() external {
+        ICreateX createX = ICreateX(0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed);
+
+        vm.createSelectFork("sepolia");
+
+        address sender = msg.sender;
+
+        // Construct random seeds we don't care about
+        bytes32 seed1 = keccak256(abi.encodePacked(block.timestamp, block.prevrandao, block.coinbase));
+        bytes32 seed2 = keccak256(abi.encodePacked(seed1, block.timestamp, block.prevrandao, block.coinbase));
+
+        // Construct CreateX salts with msg.sender protection but no cross-chain protection
+        bytes32 salt1 = bytes32(abi.encodePacked(bytes20(sender), bytes1(0x00), seed1));
+        bytes32 salt2 = bytes32(abi.encodePacked(bytes20(sender), bytes1(0x00), seed2));
+
+        // Compute the guarded salts for address prediction
+        bytes32 guardedSalt1 = keccak256(abi.encodePacked(bytes32(uint256(uint160(msg.sender))), salt1));
+        bytes32 guardedSalt2 = keccak256(abi.encodePacked(bytes32(uint256(uint160(msg.sender))), salt2));
+
+        address arbitrumSepoliaBroadcaster = createX.computeCreate3Address(guardedSalt1);
+        address stateOracle = createX.computeCreate3Address(guardedSalt2);
+
+        address arbSepoliaL1Inbox = 0xaAe29B0366299461418F5324a79Afc425BE5ae21; // Sepolia L1 Inbox
+
+        vm.startBroadcast();
+
+        MockBridge bridge = new MockBridge();
+        bytes memory arbitrumSepoliaBroadcasterDeploymentCode =
+            abi.encodePacked(type(ArbitrumBroadcaster).creationCode, abi.encode(arbSepoliaL1Inbox, bridge, stateOracle));
+        createX.deployCreate3(salt1, arbitrumSepoliaBroadcasterDeploymentCode);
+
+        vm.stopBroadcast();
+
+        vm.createSelectFork("arbitrum_sepolia");
+        vm.startBroadcast();
+
+        bytes memory stateOracleDeploymentCode =
+            abi.encodePacked(type(ArbitrumStateOracle).creationCode, abi.encode(arbitrumSepoliaBroadcaster));
+        address deployedStateOracle = createX.deployCreate3(salt2, stateOracleDeploymentCode);
+
+        require(deployedStateOracle == stateOracle, "State oracle deployment failed");
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/ICreateX.sol
+++ b/contracts/script/ICreateX.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.4;
+
+/**
+ * @title CreateX Factory Interface Definition
+ * @author pcaversaccio (https://web.archive.org/web/20230921103111/https://pcaversaccio.com/)
+ * @custom:coauthor Matt Solomon (https://web.archive.org/web/20230921103335/https://mattsolomon.dev/)
+ */
+interface ICreateX {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                            TYPES                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    struct Values {
+        uint256 constructorAmount;
+        uint256 initCallAmount;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           EVENTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    event ContractCreation(address indexed newContract, bytes32 indexed salt);
+    event ContractCreation(address indexed newContract);
+    event Create3ProxyContractCreation(address indexed newContract, bytes32 indexed salt);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CUSTOM ERRORS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    error FailedContractCreation(address emitter);
+    error FailedContractInitialisation(address emitter, bytes revertData);
+    error InvalidSalt(address emitter);
+    error InvalidNonceValue(address emitter);
+    error FailedEtherTransfer(address emitter, bytes revertData);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           CREATE                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function deployCreate(bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreateClone(address implementation, bytes memory data) external payable returns (address proxy);
+
+    function computeCreateAddress(address deployer, uint256 nonce) external view returns (address computedAddress);
+
+    function computeCreateAddress(uint256 nonce) external view returns (address computedAddress);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           CREATE2                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function deployCreate2(bytes32 salt, bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate2(bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate2AndInit(
+        bytes32 salt,
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreate2AndInit(bytes32 salt, bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreate2Clone(bytes32 salt, address implementation, bytes memory data)
+        external
+        payable
+        returns (address proxy);
+
+    function deployCreate2Clone(address implementation, bytes memory data) external payable returns (address proxy);
+
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer)
+        external
+        pure
+        returns (address computedAddress);
+
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash)
+        external
+        view
+        returns (address computedAddress);
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           CREATE3                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function deployCreate3(bytes32 salt, bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate3(bytes memory initCode) external payable returns (address newContract);
+
+    function deployCreate3AndInit(
+        bytes32 salt,
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
+
+    function deployCreate3AndInit(bytes32 salt, bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        external
+        payable
+        returns (address newContract);
+
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
+
+    function computeCreate3Address(bytes32 salt, address deployer) external pure returns (address computedAddress);
+
+    function computeCreate3Address(bytes32 salt) external view returns (address computedAddress);
+}

--- a/contracts/script/KeystoreValidator.s.sol
+++ b/contracts/script/KeystoreValidator.s.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { StorageProofVerifier } from "../src/StorageProofVerifier.sol";
+import { StorageProofVerifier } from "../src/state/StorageProofVerifier.sol";
 import { OPStackStateOracle } from "../src/state/OPStackStateOracle.sol";
 import { KeystoreValidator } from "../src/KeystoreValidator.sol";
-import { ECDSAConsumer } from "../test/example/ECDSAConsumer.sol";
 
 import { Script, safeconsole as console } from "forge-std/Script.sol";
 

--- a/contracts/src/KeystoreValidator.sol
+++ b/contracts/src/KeystoreValidator.sol
@@ -21,6 +21,10 @@ import { IERC165 } from "@openzeppelin/contracts/interfaces/IERC165.sol";
 contract KeystoreValidator is ERC7579ValidatorBase, IERC6900ValidationModule {
     /// @dev Per userOp. The expected structure of the `signature` field in
     /// `PackedUserOperation`
+    ///
+    /// Note that these fields are subject to manipulation by the bundler and/or
+    /// sequencer. While these entities cannot execute unauthenticated actions,
+    /// they can alter the caching behavior from the one intended by the user.
     struct AuthenticationData {
         // Parsed as KeystoreIMT.KeyDataMerkleProof. If empty, key data will be
         // read from local cache, skipping the need for a state root read
@@ -242,22 +246,22 @@ contract KeystoreValidator is ERC7579ValidatorBase, IERC6900ValidationModule {
 
     /// @notice Update the state root invalidation time for the smart account
     ///
-    /// @param newstateRootValidityInterval The new state root validity window
-    function setstateRootValidityInterval(uint32 newstateRootValidityInterval) external {
+    /// @param newStateRootValidityInterval The new state root validity window
+    function setStateRootValidityInterval(uint32 newStateRootValidityInterval) external {
         AccountData storage $ = accountData[msg.sender];
         if ($.keystoreAddress == bytes32(0)) revert NotInitialized(msg.sender);
 
-        $.stateRootValidityInterval = newstateRootValidityInterval;
+        $.stateRootValidityInterval = newStateRootValidityInterval;
     }
 
     /// @notice Update the cache invalidation time for the smart account
     ///
-    /// @param newcacheValidityInterval The new cache invalidation time
-    function setcacheValidityInterval(uint32 newcacheValidityInterval) external {
+    /// @param newCacheValidityInterval The new cache invalidation time
+    function setCacheValidityInterval(uint32 newCacheValidityInterval) external {
         AccountData storage $ = accountData[msg.sender];
         if ($.keystoreAddress == bytes32(0)) revert NotInitialized(msg.sender);
 
-        $.cacheValidityInterval = newcacheValidityInterval;
+        $.cacheValidityInterval = newCacheValidityInterval;
     }
 
     function isValidSignatureWithSender(address, bytes32, bytes calldata) external pure override returns (bytes4) {

--- a/contracts/src/KeystoreValidator.sol
+++ b/contracts/src/KeystoreValidator.sol
@@ -216,6 +216,28 @@ contract KeystoreValidator is ERC7579ValidatorBase, IERC6900ValidationModule {
         );
     }
 
+    /// @notice Decodes the `signature` field of a `PackedUserOperation`
+    ///
+    /// @dev It should be noted that the user does not sign over the `signature`
+    /// field, so it is subject to manipulation by the bundler. This is most
+    /// relevant for the caching behavior, which can be altered by the bundler.
+    /// We analyze the security implications below.
+    ///
+    /// There are two scenarios to consider:
+    ///
+    /// 1. The bundler forces the user to use a Merkle proof when they want to
+    ///    read from the cache. This increases the cost of 4337 validation and
+    ///    the calldata footprint of the `userOp`. Users are expected to pick an
+    ///    appropriate `preVerificationGas` and `verificationGasLimit` to upper
+    ///    bound the cost of the `userOp`.
+    ///
+    /// 2. The bundler forces the user to read from the cache when they wanted
+    ///    to perform a fresh read with a Merkle proof.
+    ///      - If the signature is valid against the old signing data, the only
+    ///        impact is cache validity is not extended.
+    ///      - If the signature is only valid against the new signing data, the
+    ///        outcome is equivalent to that of censorship, which the bundler
+    ///        is capable of anyways.
     function _decodeUserOpSignature(bytes calldata signature) internal pure returns (AuthenticationData calldata out) {
         /// @solidity memory-safe-assembly
         assembly {

--- a/contracts/src/broadcast/ArbitrumBroadcaster.sol
+++ b/contracts/src/broadcast/ArbitrumBroadcaster.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IAxiomKeystoreRollup } from "../interfaces/IAxiomKeystoreRollup.sol";
+import { IArbitrumStateOracle } from "../interfaces/IArbitrumStateOracle.sol";
+import { IArbitrumL1Inbox } from "../interfaces/IArbitrumL1Inbox.sol";
+
+/// @dev This contract is expected to be paired with an `ArbitrumStateOracle`.
+contract ArbitrumBroadcaster {
+    IAxiomKeystoreRollup public immutable KEYSTORE_ROLLUP;
+
+    IArbitrumL1Inbox public immutable ARBITRUM_INBOX;
+
+    address public immutable L2_KEYSTORE_STATE_ORACLE;
+
+    error InvalidOutputRoot(bytes32 derivedOutputRoot, bytes32 keystoreOutputRoot);
+
+    constructor(address arbitrumInbox, address keystoreRollup, address l2KeystoreStateOracle) {
+        ARBITRUM_INBOX = IArbitrumL1Inbox(arbitrumInbox);
+        KEYSTORE_ROLLUP = IAxiomKeystoreRollup(keystoreRollup);
+        L2_KEYSTORE_STATE_ORACLE = l2KeystoreStateOracle;
+    }
+
+    /// @notice Broadcast a keystore state root to the L2 Keystore State Oracle.
+    ///
+    /// @dev There are two types of fees that the creator of a retryable ticket must pay for.
+    ///
+    /// 1. The submission fee which is computed as a function of the calldata
+    ///    length of the L2 call and the L1 `block.basefee` at the time of ticket
+    ///    creation. This is upper-bounded by `maxSubmissionCost`.
+    /// 2. The execution fee on L2 which is charged at the time of L2 execution.
+    /// This is upper-bounded by `maxFeePerGas * gasLimit`.
+    ///
+    /// During redemption on L2, the specified call will be front-run with a transaction that:
+    /// - Mints the entire `msg.value` of this call to this contract's alias address.
+    /// - Charges the exact submission fee.
+    /// - Refunds `maxSubmissionCost - submissionCost` to `excessFeeRefundAddress`.
+    /// - Charges the exact execution fee as `feePerGas * gasLimit`.
+    /// - Refunds `(maxFeePerGas - feePerGas) * gasLimit` to `excessFeeRefundAddress`.
+    ///
+    /// This contract is expected to be paired with an `ArbitrumStateOracle`. If
+    /// the `gasLimit` is chosen properly, the redemption of the ticket is
+    /// expected to never fail. In the case of failure, the
+    /// `ArbitrumStateOracle` is resistant to out of order execution by
+    /// enforcing an always-increasing timestamp.
+    ///
+    /// @param outputRootPreimage The preimage of the output root, used for decommitting the state root.
+    /// @param gasLimit The gas limit for the L2 call.
+    /// @param maxFeePerGas The maximum amount to pay for one unit of L2 gas.
+    /// @param maxSubmissionCost The maximum amount to pay for the submission fee.
+    /// @param excessFeeRefundAddress The address to refund excess fees to.
+    function broadcast(
+        IAxiomKeystoreRollup.OutputRootPreimage calldata outputRootPreimage,
+        uint32 gasLimit,
+        uint256 maxFeePerGas,
+        uint256 maxSubmissionCost,
+        address excessFeeRefundAddress
+    ) public payable {
+        bytes32 outputRoot = KEYSTORE_ROLLUP.latestOutputRoot();
+        uint48 l1BlockTimestamp = uint48(block.timestamp);
+
+        bytes32 derivedOutputRoot;
+        /// @solidity memory-safe-assembly
+        assembly {
+            let fmp := mload(0x40)
+            calldatacopy(fmp, outputRootPreimage, 0x60)
+            derivedOutputRoot := keccak256(fmp, 0x60)
+        }
+
+        if (derivedOutputRoot != outputRoot) revert InvalidOutputRoot(derivedOutputRoot, outputRoot);
+
+        bytes memory _calldata =
+            abi.encodeCall(IArbitrumStateOracle.cacheStateRoot, (outputRootPreimage.stateRoot, l1BlockTimestamp));
+
+        ARBITRUM_INBOX.createRetryableTicket{ value: msg.value }({
+            to: address(L2_KEYSTORE_STATE_ORACLE),
+            l2CallValue: 0,
+            maxSubmissionCost: maxSubmissionCost,
+            excessFeeRefundAddress: excessFeeRefundAddress,
+            // We can just set to address(0) since there is no `l2CallValue`
+            callValueRefundAddress: address(0),
+            gasLimit: gasLimit,
+            maxFeePerGas: maxFeePerGas,
+            data: _calldata
+        });
+    }
+}

--- a/contracts/src/broadcast/ArbitrumBroadcaster.sol
+++ b/contracts/src/broadcast/ArbitrumBroadcaster.sol
@@ -69,8 +69,9 @@ contract ArbitrumBroadcaster {
 
         if (derivedOutputRoot != outputRoot) revert InvalidOutputRoot(derivedOutputRoot, outputRoot);
 
-        bytes memory _calldata =
-            abi.encodeCall(IArbitrumStateOracle.cacheStateRoot, (outputRootPreimage.stateRoot, l1BlockTimestamp));
+        bytes memory _calldata = abi.encodeCall(
+            IArbitrumStateOracle.cacheKeystoreStateRoot, (outputRootPreimage.stateRoot, l1BlockTimestamp)
+        );
 
         ARBITRUM_INBOX.createRetryableTicket{ value: msg.value }({
             to: address(L2_KEYSTORE_STATE_ORACLE),

--- a/contracts/src/interfaces/IArbitrumL1Inbox.sol
+++ b/contracts/src/interfaces/IArbitrumL1Inbox.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IArbitrumL1Inbox {
+    function createRetryableTicket(
+        address to,
+        uint256 l2CallValue,
+        uint256 maxSubmissionCost,
+        address excessFeeRefundAddress,
+        address callValueRefundAddress,
+        uint256 gasLimit,
+        uint256 maxFeePerGas,
+        bytes calldata data
+    ) external payable returns (uint256);
+}

--- a/contracts/src/interfaces/IArbitrumStateOracle.sol
+++ b/contracts/src/interfaces/IArbitrumStateOracle.sol
@@ -2,5 +2,5 @@
 pragma solidity ^0.8.0;
 
 interface IArbitrumStateOracle {
-    function cacheStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) external;
+    function cacheKeystoreStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) external;
 }

--- a/contracts/src/interfaces/IArbitrumStateOracle.sol
+++ b/contracts/src/interfaces/IArbitrumStateOracle.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IArbitrumStateOracle {
+    function cacheStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) external;
+}

--- a/contracts/src/interfaces/IAxiomKeystoreRollup.sol
+++ b/contracts/src/interfaces/IAxiomKeystoreRollup.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IAxiomKeystoreRollup {
+    struct OutputRootPreimage {
+        bytes32 stateRoot;
+        bytes32 withdrawalsRoot;
+        bytes32 lastValidBlockhash;
+    }
+
+    function latestOutputRoot() external view returns (bytes32);
+}

--- a/contracts/src/interfaces/IKeystoreStateOracle.sol
+++ b/contracts/src/interfaces/IKeystoreStateOracle.sol
@@ -2,11 +2,5 @@
 pragma solidity ^0.8.0;
 
 interface IKeystoreStateOracle {
-    struct OutputRootPreimage {
-        bytes32 stateRoot;
-        bytes32 withdrawalsRoot;
-        bytes32 lastValidBlockhash;
-    }
-
     function keystoreStateRoots(bytes32 keystoreStateRoot) external view returns (uint48 l1BlockTimestamp);
 }

--- a/contracts/src/state/ArbitrumStateOracle.sol
+++ b/contracts/src/state/ArbitrumStateOracle.sol
@@ -21,7 +21,7 @@ contract ArbitrumStateOracle is KeystoreStateOracle {
     ///
     /// @param stateRoot The state root to cache.
     /// @param l1BlockTimestamp The L1 block timestamp from which the state root was read.
-    function cacheStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) external {
+    function cacheKeystoreStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) external {
         if (_l1Sender() != BROADCASTER) revert InvalidL1Sender(_l1Sender());
 
         _cacheKeystoreStateRoot(stateRoot, l1BlockTimestamp);

--- a/contracts/src/state/ArbitrumStateOracle.sol
+++ b/contracts/src/state/ArbitrumStateOracle.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { KeystoreStateOracle } from "./KeystoreStateOracle.sol";
+
+/// @dev This contract is expected to be paired with an `ArbitrumBroadcaster`.
+contract ArbitrumStateOracle is KeystoreStateOracle {
+    address public immutable BROADCASTER;
+
+    error InvalidL1Sender(address l1Sender);
+
+    constructor(address broadcaster) {
+        BROADCASTER = broadcaster;
+    }
+
+    /// @notice Caches the state root for the given L1 block timestamp.
+    /// @dev This function is expected to be called by the `ArbitrumBroadcaster` from L1.
+    ///
+    /// This function is resistant to out of order execution by enforcing an
+    /// always-increasing timestamp.
+    ///
+    /// @param stateRoot The state root to cache.
+    /// @param l1BlockTimestamp The L1 block timestamp from which the state root was read.
+    function cacheStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) external {
+        if (_l1Sender() != BROADCASTER) revert InvalidL1Sender(_l1Sender());
+
+        _cacheKeystoreStateRoot(stateRoot, l1BlockTimestamp);
+    }
+
+    function _l1Sender() internal view returns (address out) {
+        // Underflow desirable
+        assembly {
+            out := sub(caller(), 0x1111000000000000000000000000000000001111)
+        }
+    }
+}

--- a/contracts/src/state/KeystoreStateOracle.sol
+++ b/contracts/src/state/KeystoreStateOracle.sol
@@ -4,24 +4,23 @@ pragma solidity 0.8.26;
 import { IKeystoreStateOracle } from "../interfaces/IKeystoreStateOracle.sol";
 
 abstract contract KeystoreStateOracle is IKeystoreStateOracle {
-    error InvalidOutputRoot(bytes32 derivedOutputRoot, bytes32 keystoreOutputRoot);
+    error TimestampTooOld();
 
     bytes32 public latestStateRoot;
     mapping(bytes32 keystoreStateRoot => uint48 l1BlockTimestamp) public keystoreStateRoots;
 
-    address public immutable KEYSTORE_BRIDGE_ADDRESS;
-    bytes32 public immutable KEYSTORE_STATE_ROOT_STORAGE_SLOT;
+    function _cacheKeystoreStateRoot(bytes32 stateRoot, uint48 l1BlockTimestamp) internal {
+        // We don't want to allow older timestamps to prevent frontrunning
+        // of would-be-valid userOps ending up as expired.
+        uint48 currentTimestamp = keystoreStateRoots[stateRoot];
+        if (l1BlockTimestamp < currentTimestamp) revert TimestampTooOld();
 
-    constructor(address keystoreBridgeAddress, bytes32 keystoreStateRootStorageSlot) {
-        KEYSTORE_BRIDGE_ADDRESS = keystoreBridgeAddress;
-        KEYSTORE_STATE_ROOT_STORAGE_SLOT = keystoreStateRootStorageSlot;
+        // If caching a state root that has already been cached, we'll want to
+        // update its associated blockTimestamp first
+        keystoreStateRoots[stateRoot] = l1BlockTimestamp;
+
+        // The first time a state root is cached, `latestTimestamp` will be 0.
+        uint48 latestTimestamp = keystoreStateRoots[latestStateRoot];
+        if (l1BlockTimestamp > latestTimestamp) latestStateRoot = stateRoot;
     }
-
-    // TODO: Add this back in with check on msg.sender == canonicalBridge and l1Sender == broadcaster
-    // function cacheKeystoreStateRootNative(
-    //     bytes32 keystoreOutputRoot,
-    //     uint48 l1BlockTimestamp,
-    //     OutputRootPreimage calldata outputRootPreimage
-    // ) external {
-    // }
 }

--- a/contracts/src/state/OPStackStateOracle.sol
+++ b/contracts/src/state/OPStackStateOracle.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { IStorageProofVerifier } from "../interfaces/IStorageProofVerifier.sol";
+import { IAxiomKeystoreRollup } from "../interfaces/IAxiomKeystoreRollup.sol";
 import { IL1Block } from "../interfaces/IL1Block.sol";
 import { RLPReader } from "../vendor/optimism-mpt/rlp/RLPReader.sol";
 import { KeystoreStateOracle } from "./KeystoreStateOracle.sol";
@@ -14,11 +15,14 @@ contract OPStackStateOracle is Ownable2Step, KeystoreStateOracle {
 
     event BlockhashCached(bytes32 _blockhash);
 
-    error StorageProofTooOld();
-
     error BlockhashNotFound(bytes32 _blockhash);
 
+    error InvalidOutputRoot(bytes32 derivedOutputRoot, bytes32 keystoreOutputRoot);
+
     mapping(bytes32 _blockhash => bool) public blockhashes;
+
+    address public immutable KEYSTORE_BRIDGE_ADDRESS;
+    bytes32 public immutable KEYSTORE_STATE_ROOT_STORAGE_SLOT;
 
     IStorageProofVerifier public storageProofVerifier;
 
@@ -28,7 +32,9 @@ contract OPStackStateOracle is Ownable2Step, KeystoreStateOracle {
         IStorageProofVerifier _storageProofVerifier,
         address keystoreBridgeAddress,
         bytes32 keystoreStateRootStorageSlot
-    ) Ownable(msg.sender) KeystoreStateOracle(keystoreBridgeAddress, keystoreStateRootStorageSlot) {
+    ) Ownable(msg.sender) {
+        KEYSTORE_BRIDGE_ADDRESS = keystoreBridgeAddress;
+        KEYSTORE_STATE_ROOT_STORAGE_SLOT = keystoreStateRootStorageSlot;
         storageProofVerifier = _storageProofVerifier;
     }
 
@@ -55,9 +61,9 @@ contract OPStackStateOracle is Ownable2Step, KeystoreStateOracle {
         blockhashes[_blockhash] = true;
     }
 
-    function cacheKeystoreStateRootWithProof(
+    function cacheStateRootWithProof(
         IStorageProofVerifier.StorageProof calldata storageProof,
-        OutputRootPreimage calldata outputRootPreimage
+        IAxiomKeystoreRollup.OutputRootPreimage calldata outputRootPreimage
     ) external {
         (bytes32 keystoreOutputRoot, bytes32 _blockhash) = storageProofVerifier.verifyStorageSlot({
             storageProof: storageProof,
@@ -81,17 +87,6 @@ contract OPStackStateOracle is Ownable2Step, KeystoreStateOracle {
         // TODO: This needs to be revisited. The blockTimestamp appears to be a right-padded uint32 value.
         uint48 blockTimestamp = uint32(bytes4(bytes32(RLPReader.readBytes(blockHeaderRlp[11]))));
 
-        // We don't want to allow older storage proofs to prevent frontrunning
-        // of would-be-valid userOps ending up as expired.
-        uint48 currentTimestamp = keystoreStateRoots[keystoreStateRoot];
-        if (blockTimestamp < currentTimestamp) revert StorageProofTooOld();
-
-        // If caching a state root that has already been cached, we'll want to
-        // update its associated blockTimestamp first
-        keystoreStateRoots[keystoreStateRoot] = blockTimestamp;
-
-        // For the first state root being cached, `latestTimestamp` will be 0.
-        uint48 latestTimestamp = keystoreStateRoots[latestStateRoot];
-        if (blockTimestamp > latestTimestamp) latestStateRoot = keystoreStateRoot;
+        _cacheKeystoreStateRoot(keystoreStateRoot, blockTimestamp);
     }
 }

--- a/contracts/src/state/OPStackStateOracle.sol
+++ b/contracts/src/state/OPStackStateOracle.sol
@@ -61,7 +61,7 @@ contract OPStackStateOracle is Ownable2Step, KeystoreStateOracle {
         blockhashes[_blockhash] = true;
     }
 
-    function cacheStateRootWithProof(
+    function cacheKeystoreStateRootWithProof(
         IStorageProofVerifier.StorageProof calldata storageProof,
         IAxiomKeystoreRollup.OutputRootPreimage calldata outputRootPreimage
     ) external {

--- a/contracts/src/state/StorageProofVerifier.sol
+++ b/contracts/src/state/StorageProofVerifier.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { RLPReader } from "./vendor/optimism-mpt/rlp/RLPReader.sol";
-import { SecureMerkleTrie } from "./vendor/optimism-mpt/trie/SecureMerkleTrie.sol";
-import { IStorageProofVerifier } from "./interfaces/IStorageProofVerifier.sol";
+import { RLPReader } from "../vendor/optimism-mpt/rlp/RLPReader.sol";
+import { SecureMerkleTrie } from "../vendor/optimism-mpt/trie/SecureMerkleTrie.sol";
+import { IStorageProofVerifier } from "../interfaces/IStorageProofVerifier.sol";
 
 contract StorageProofVerifier is IStorageProofVerifier {
     error InvalidBlockHeader();

--- a/contracts/test/KeystoreValidator.t.sol
+++ b/contracts/test/KeystoreValidator.t.sol
@@ -76,7 +76,7 @@ contract KeystoreValidatorTest is RhinestoneModuleKit, Test {
             storageProof: storageProof
         });
 
-        stateOracle.cacheStateRootWithProof(
+        stateOracle.cacheKeystoreStateRootWithProof(
             _storageProof,
             IAxiomKeystoreRollup.OutputRootPreimage({
                 stateRoot: bytes32(0x3c88834ecd749dae9348033b2a889acad890fa045f84061d2347dba67facda8c),

--- a/contracts/test/KeystoreValidator.t.sol
+++ b/contracts/test/KeystoreValidator.t.sol
@@ -5,10 +5,10 @@ import { OPStackStateOracle } from "../src/state/OPStackStateOracle.sol";
 import { KeystoreValidator } from "../src/KeystoreValidator.sol";
 import { KeystoreIMT } from "../src/libraries/KeystoreIMT.sol";
 import { ECDSAConsumer } from "./example/ECDSAConsumer.sol";
-import { StorageProofVerifier } from "../src/StorageProofVerifier.sol";
+import { StorageProofVerifier } from "../src/state/StorageProofVerifier.sol";
 import { IStorageProofVerifier } from "../src/interfaces/IStorageProofVerifier.sol";
 import { IKeystoreStateOracle } from "../src/interfaces/IKeystoreStateOracle.sol";
-
+import { IAxiomKeystoreRollup } from "../src/interfaces/IAxiomKeystoreRollup.sol";
 import { RhinestoneModuleKit, ModuleKitHelpers, AccountInstance, UserOpData } from "modulekit/ModuleKit.sol";
 import { MODULE_TYPE_VALIDATOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { IEntryPoint, PackedUserOperation } from "modulekit/external/ERC4337.sol";
@@ -76,9 +76,9 @@ contract KeystoreValidatorTest is RhinestoneModuleKit, Test {
             storageProof: storageProof
         });
 
-        stateOracle.cacheKeystoreStateRootWithProof(
+        stateOracle.cacheStateRootWithProof(
             _storageProof,
-            IKeystoreStateOracle.OutputRootPreimage({
+            IAxiomKeystoreRollup.OutputRootPreimage({
                 stateRoot: bytes32(0x3c88834ecd749dae9348033b2a889acad890fa045f84061d2347dba67facda8c),
                 withdrawalsRoot: bytes32(0x0000000000000000000000000000000000000000000000000000000000000000),
                 lastValidBlockhash: bytes32(0x0000000000000000000000000000000000000000000000000000000000000000)


### PR DESCRIPTION
This PR adds support for bridging state roots across arbitrum bridges. There are two relevant contracts:

- `ArbitrumBroadcaster` on L1 reads the `latestOutputRoot()` from the bridge, decommits the state root and pushes it across the bridge.
- `ArbitrumStateOracle` receives these state roots across bridge and exposes them to the L2's execution env.

The full flow was tested on Sepolia < - > Arb Sepolia and the deployment script showcases an example deployment. We use a contract factory to easily predict deployment addresses since the pair of contracts needs to be able to refer to each other, set during contract construction. The relevant test transactions are:

- [Broadcast](https://sepolia.etherscan.io/tx/0x88c2764044dc512a6ac207aac2a93f24f1c12e65cef4544a878ef3d888ab0ac2) of a mock state root across the Arb Sepolia bridge
- [Auto-redemption](https://sepolia.arbiscan.io/tx/0x46f7cb1da2c0cd31cb68aa8b22b28d17e2c420b810eb7ec36411b30cc03a65d4) of the retryable ticket

Closes INT-3968
